### PR TITLE
fix syntax error for linux build

### DIFF
--- a/prboom2/src/RT/rt_main.c
+++ b/prboom2/src/RT/rt_main.c
@@ -69,7 +69,7 @@ void RT_Init()
   {
     .dpy = wmInfo.info.x11.display,
     .window = wmInfo.info.x11.window
-  }
+  };
 #endif
 
   RgInstanceCreateInfo info =


### PR DESCRIPTION
Fix error:

```
/build/prboom-plus-rt-d3f67b2/src/RT/rt_main.c: In function 'RT_Init':
/build/prboom-plus-rt-d3f67b2/src/RT/rt_main.c:75:3: error: expected ',' or ';' before 'RgInstanceCreateInfo'
   75 |   RgInstanceCreateInfo info =
      |   ^~~~~~~~~~~~~~~~~~~~
```