### PR TITLE
Do not enable radsuit palette unconditionally

### DIFF
--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -870,7 +870,10 @@ static void ST_doPaletteStuff(void)
 
     if (palette_onpowers && plyr->powers[pw_ironfeet])
     {
-      rt_powerupflags |= RT_POWERUP_FLAG_RADIATIONSUIT_BIT;
+      if ((plyr->powers[pw_ironfeet] > 4 * 32 || plyr->powers[pw_ironfeet] & 8))
+      {
+        rt_powerupflags |= RT_POWERUP_FLAG_RADIATIONSUIT_BIT;
+      }
     }
 
     if (palette_onpowers && plyr->powers[pw_strength])


### PR DESCRIPTION
This assert (https://github.com/sultim-t/prboom-plus-rt/blob/master/prboom2/src/st_stuff.c#L885) will always fire when the radsuit is about to die out because the radsuit powerup is enabled here (https://github.com/sultim-t/prboom-plus-rt/blob/master/prboom2/src/st_stuff.c#L873) but the palette is disabled when the remaining ticks falls below 128 here (https://github.com/sultim-t/prboom-plus-rt/blob/master/prboom2/src/st_stuff.c#L819)
This bug is 100% reproducible for me; tested on E1M5 when using the secret radsuit next to the secret chainsaw.